### PR TITLE
카카오페이 연동

### DIFF
--- a/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/payment/PaymentHandler.kt
+++ b/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/payment/PaymentHandler.kt
@@ -1,0 +1,30 @@
+package com.usktea.plainoldv2.application.endpoints.payment
+
+import com.usktea.plainoldv2.domain.payment.PaymentReadyRequestDto
+import com.usktea.plainoldv2.domain.payment.application.PaymentServiceFactory
+import com.usktea.plainoldv2.domain.user.Username
+import com.usktea.plainoldv2.exception.PaymentProviderNotFoundException
+import com.usktea.plainoldv2.exception.RequestAttributeNotFoundException
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.*
+import org.springframework.web.reactive.function.server.ServerResponse.created
+import java.net.URI
+
+@Component
+class PaymentHandler(
+    private val paymentServiceFactory: PaymentServiceFactory
+) {
+    suspend fun ready(request: ServerRequest): ServerResponse {
+        val username = request.attributeOrNull("username") as? Username ?: throw RequestAttributeNotFoundException()
+        val paymentReadyRequestDto = request.awaitBody<PaymentReadyRequestDto>()
+        val paymentService =
+            paymentServiceFactory[paymentReadyRequestDto.provider] ?: throw PaymentProviderNotFoundException()
+
+        val paymentReadyResponseDto = paymentService.ready(
+            username = username, orderItems = paymentReadyRequestDto.orderItems)
+
+        return created(URI.create(paymentReadyResponseDto.prePaymentId.toString())).contentType(MediaType.APPLICATION_JSON)
+            .bodyValueAndAwait(paymentReadyResponseDto)
+    }
+}

--- a/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/payment/PaymentHandler.kt
+++ b/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/payment/PaymentHandler.kt
@@ -1,5 +1,7 @@
 package com.usktea.plainoldv2.application.endpoints.payment
 
+import com.usktea.plainoldv2.domain.payment.PaymentApproveRequest
+import com.usktea.plainoldv2.domain.payment.PaymentApproveResultDto
 import com.usktea.plainoldv2.domain.payment.PaymentReadyRequestDto
 import com.usktea.plainoldv2.domain.payment.application.PaymentServiceFactory
 import com.usktea.plainoldv2.domain.user.Username
@@ -9,6 +11,7 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.*
 import org.springframework.web.reactive.function.server.ServerResponse.created
+import org.springframework.web.reactive.function.server.ServerResponse.ok
 import java.net.URI
 
 @Component
@@ -22,9 +25,32 @@ class PaymentHandler(
             paymentServiceFactory[paymentReadyRequestDto.provider] ?: throw PaymentProviderNotFoundException()
 
         val paymentReadyResponseDto = paymentService.ready(
-            username = username, orderItems = paymentReadyRequestDto.orderItems)
+            username = username, orderItems = paymentReadyRequestDto.orderItems
+        )
 
         return created(URI.create(paymentReadyResponseDto.prePaymentId.toString())).contentType(MediaType.APPLICATION_JSON)
             .bodyValueAndAwait(paymentReadyResponseDto)
+    }
+
+    suspend fun approve(request: ServerRequest): ServerResponse {
+        val username = request.attributeOrNull("username") as? Username ?: throw RequestAttributeNotFoundException()
+        val provider = request.queryParamOrNull("provider") ?: throw RequestAttributeNotFoundException()
+        val pgToken = request.queryParamOrNull("pgToken") ?: throw RequestAttributeNotFoundException()
+        val prePaymentId =
+            request.queryParamOrNull("prePaymentId")?.toLong() ?: throw RequestAttributeNotFoundException()
+        val partnerOrderId = request.queryParamOrNull("partnerOrderId") ?: throw RequestAttributeNotFoundException()
+
+        val paymentApproveRequest = PaymentApproveRequest.from(
+            provider = provider,
+            pgToken = pgToken,
+            prePaymentId = prePaymentId,
+            partnerOrderId = partnerOrderId
+        )
+
+        val paymentService = paymentServiceFactory[provider] ?: throw PaymentProviderNotFoundException()
+
+        val aid = paymentService.approve(username = username, paymentApproveRequest = paymentApproveRequest)
+
+        return ok().contentType(MediaType.APPLICATION_JSON).bodyValueAndAwait(PaymentApproveResultDto(approveCode = aid))
     }
 }

--- a/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/payment/PaymentRouter.kt
+++ b/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/payment/PaymentRouter.kt
@@ -12,6 +12,7 @@ class PaymentRouter {
     fun paymentRouetes(handler: PaymentHandler) = coRouter {
         path(context).nest {
             POST("", handler::ready)
+            GET("", handler::approve)
         }
     }
 }

--- a/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/payment/PaymentRouter.kt
+++ b/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/payment/PaymentRouter.kt
@@ -1,0 +1,17 @@
+package com.usktea.plainoldv2.application.endpoints.payment
+
+import org.springframework.context.annotation.Bean
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.coRouter
+
+@Component
+class PaymentRouter {
+    val context = "/payments"
+
+    @Bean
+    fun paymentRouetes(handler: PaymentHandler) = coRouter {
+        path(context).nest {
+            POST("", handler::ready)
+        }
+    }
+}

--- a/application/src/test/kotlin/com/usktea/plainoldv2/application/PaymentFixtures.kt
+++ b/application/src/test/kotlin/com/usktea/plainoldv2/application/PaymentFixtures.kt
@@ -1,0 +1,37 @@
+package com.usktea.plainoldv2.application
+
+import com.usktea.plainoldv2.domain.payment.OrderItemDto
+import com.usktea.plainoldv2.domain.payment.OrderOptionDto
+import com.usktea.plainoldv2.domain.payment.PaymentReadyRequestDto
+import com.usktea.plainoldv2.domain.payment.PaymentReadyResponseDto
+
+fun createPaymentReadyRequestDto(provider: String): PaymentReadyRequestDto {
+    return PaymentReadyRequestDto(
+        provider = provider,
+        orderItems = listOf(
+            OrderItemDto(
+                productId = 1L,
+                price = 5_000L,
+                name = "T-Shirts",
+                thumbnailUrl = "1",
+                shippingFee = 1_000L,
+                freeShippingAmount = 1_000L,
+                quantity = 1L,
+                totalPrice = 5_000L,
+                option = OrderOptionDto(
+                    size = "XL",
+                    color = "RED"
+                )
+            )
+        )
+    )
+}
+
+fun createPaymentReadyResponseDto(provider: String): PaymentReadyResponseDto {
+    return PaymentReadyResponseDto(
+        paymentProvider = provider,
+        prePaymentId = 1L,
+        partnerOrderId = "Something",
+        redirectUrl = "www.some.com"
+    )
+}

--- a/application/src/test/kotlin/com/usktea/plainoldv2/application/endpoints/payment/PaymentHandlerTest.kt
+++ b/application/src/test/kotlin/com/usktea/plainoldv2/application/endpoints/payment/PaymentHandlerTest.kt
@@ -1,0 +1,59 @@
+package com.usktea.plainoldv2.application.endpoints.payment
+
+import com.ninjasquad.springmockk.MockkBean
+import com.ninjasquad.springmockk.SpykBean
+import com.usktea.plainoldv2.application.createPaymentReadyRequestDto
+import com.usktea.plainoldv2.application.createPaymentReadyResponseDto
+import com.usktea.plainoldv2.domain.oAuth.application.OAuthServiceFactory
+import com.usktea.plainoldv2.domain.payment.application.KakaopayService
+import com.usktea.plainoldv2.domain.payment.application.PaymentServiceFactory
+import com.usktea.plainoldv2.utils.JwtUtil
+import io.mockk.coEvery
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.csrf
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.reactive.server.WebTestClient
+
+const val USERNAME = "tjrxo1234@gmail.com"
+const val PROVIDER = "KAKAO"
+
+@ActiveProfiles("test")
+@WebFluxTest(PaymentRouter::class, PaymentHandler::class)
+class PaymentHandlerTest {
+    @Autowired
+    private lateinit var client: WebTestClient
+
+    @MockkBean
+    private lateinit var paymentServiceFactory: PaymentServiceFactory
+
+    @MockkBean
+    private lateinit var kakaopayService: KakaopayService
+
+    @SpykBean
+    private lateinit var jwtUtil: JwtUtil
+
+    @Test
+    fun `정확한 결제 준비 요청이 들어오면 준비 응답을 보내준다`() {
+        val token = jwtUtil.encode(USERNAME)
+        val paymentReadyRequest = createPaymentReadyRequestDto(PROVIDER)
+        val paymentReadyResponse = createPaymentReadyResponseDto(PROVIDER)
+
+        coEvery { paymentServiceFactory[PROVIDER] } returns kakaopayService
+        coEvery { kakaopayService.ready(any(), any()) } returns paymentReadyResponse
+
+        client.mutateWith(csrf()).mutateWith(mockUser())
+            .post()
+            .uri("/payments")
+            .header("Authorization", "Bearer $token")
+            .bodyValue(paymentReadyRequest)
+            .exchange()
+            .expectStatus().isCreated
+            .expectBody()
+            .jsonPath("$.prePaymentId").exists()
+            .jsonPath("$.redirectUrl").exists()
+    }
+}
+

--- a/library/src/main/kotlin/com/usktea/plainoldv2/config/PaymentConfiguration.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/config/PaymentConfiguration.kt
@@ -1,0 +1,48 @@
+package com.usktea.plainoldv2.config
+
+import com.usktea.plainoldv2.domain.payment.application.KakaopayService
+import com.usktea.plainoldv2.domain.payment.application.PaymentOrderAmountService
+import com.usktea.plainoldv2.domain.payment.application.PaymentService
+import com.usktea.plainoldv2.domain.payment.application.PaymentServiceFactory
+import com.usktea.plainoldv2.domain.payment.repository.PrePaymentRepository
+import com.usktea.plainoldv2.domain.user.repository.UserRepository
+import com.usktea.plainoldv2.properties.KakaopayProperties
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+@EnableConfigurationProperties(KakaopayProperties::class)
+class PaymentConfiguration {
+    @Autowired
+    private lateinit var kakaopayProperties: KakaopayProperties
+
+    @Autowired
+    private lateinit var orderAmountService: PaymentOrderAmountService
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var prePaymentRepository: PrePaymentRepository
+
+    @Autowired
+    private lateinit var webClient: WebClient
+
+    @Bean
+    fun paymentServiceFactory(): PaymentServiceFactory {
+        val services: MutableMap<String, PaymentService> = mutableMapOf()
+
+        services["KAKAOPAY"] = KakaopayService(
+            properties = kakaopayProperties,
+            paymentOrderAmountService = orderAmountService,
+            prePaymentRepository = prePaymentRepository,
+            userRepository = userRepository,
+            client = webClient
+        )
+
+        return PaymentServiceFactory(services)
+    }
+}

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/category/repository/CategoryRepository.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/category/repository/CategoryRepository.kt
@@ -5,6 +5,7 @@ import com.linecorp.kotlinjdsl.spring.data.reactive.query.SpringDataHibernateMut
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.listQuery
 import com.usktea.plainoldv2.domain.category.Category
 import com.usktea.plainoldv2.support.BaseRepository
+import io.smallrye.mutiny.coroutines.awaitSuspending
 import org.hibernate.reactive.mutiny.Mutiny.SessionFactory
 import org.springframework.stereotype.Repository
 
@@ -26,7 +27,9 @@ class CategoryRepository(
     }
 
     override suspend fun save(entity: Category): Category {
-        //TODO
-        return entity
+        return entity.also {
+            sessionFactory.withSession { session -> session.persist(it).flatMap { session.flush() } }
+                .awaitSuspending()
+        }
     }
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/option/repository/OptionRepository.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/option/repository/OptionRepository.kt
@@ -3,7 +3,6 @@ package com.usktea.plainoldv2.domain.option.repository
 import com.linecorp.kotlinjdsl.querydsl.expression.col
 import com.linecorp.kotlinjdsl.querydsl.from.fetch
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.SpringDataHibernateMutinyReactiveQueryFactory
-import com.linecorp.kotlinjdsl.spring.data.reactive.query.deleteQuery
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.singleQuery
 import com.usktea.plainoldv2.domain.option.OptionData
 import com.usktea.plainoldv2.support.BaseRepository
@@ -15,7 +14,7 @@ import org.springframework.stereotype.Repository
 class OptionRepository(
     private val sessionFactory: Mutiny.SessionFactory,
     private val queryFactory: SpringDataHibernateMutinyReactiveQueryFactory
-) : BaseRepository<OptionData>{
+) : BaseRepository<OptionData> {
     override suspend fun findAll(): List<OptionData> {
         TODO("Not yet implemented")
     }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/order/Order.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/order/Order.kt
@@ -28,7 +28,7 @@ class Order(
     val payment: Payment,
 
     @Enumerated(EnumType.STRING)
-    val status: OrderStatus,
+    var status: OrderStatus,
 
     @Embedded
     @AttributeOverride(name = "amount", column = Column(name = "shippingFee"))
@@ -38,6 +38,11 @@ class Order(
     @AttributeOverride(name = "amount", column = Column(name = "cost"))
     val cost: Price,
 ) : BaseEntity(id) {
+    init {
+        if (this.payment.method == PaymentMethod.KAKAOPAY) {
+            this.status = OrderStatus.PREPARING
+        }
+    }
     companion object {
         fun of(oderNumber: OrderNumber, orderRequest: OrderRequest): Order {
             return Order(

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/order/OrderDtos.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/order/OrderDtos.kt
@@ -23,9 +23,16 @@ data class OrderItemDto(
     val option: OrderOptionDto?
 )
 
-data class OrderOptionDto(val size: String, val color: String)
+data class OrderOptionDto(
+    val size: String,
+    val color: String
+)
 
-data class OrdererDto(val name: String, val phoneNumber: String, val email: String)
+data class OrdererDto(
+    val name: String,
+    val phoneNumber: String,
+    val email: String
+)
 
 data class ReceiverDto(
     val name: String,
@@ -57,9 +64,16 @@ data class OrderAddressDto(
     }
 }
 
-data class ShippingInformationDto(val receiver: ReceiverDto, val address: OrderAddressDto, val message: String = "")
+data class ShippingInformationDto(
+    val receiver: ReceiverDto,
+    val address: OrderAddressDto,
+    val message: String = ""
+)
 
-data class PaymentDto(val method: String, val payer: String)
+data class PaymentDto(
+    val method: String,
+    val payer: String
+)
 
 data class OrderRequest(
     val username: Username,

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/OrderLine.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/OrderLine.kt
@@ -1,0 +1,116 @@
+package com.usktea.plainoldv2.domain.payment
+
+import com.usktea.plainoldv2.exception.ErrorMessage
+import jakarta.persistence.*
+
+@Embeddable
+data class OrderLine(
+    val productId: Long,
+
+    @AttributeOverride(name = "value", column = Column(name = "productName"))
+    val productName: ProductName,
+
+    @AttributeOverride(name = "amount", column = Column(name = "price"))
+    val price: Price,
+
+    @AttributeOverride(name = "value", column = Column(name = "thumbnailUrl"))
+    val thumbnailUrl: ThumbnailUrl,
+
+    @AttributeOverride(name = "amount", column = Column(name = "quantity"))
+    val quantity: Quantity,
+
+    @AttributeOverride(name = "amount", column = Column(name = "totalPrice"))
+    val totalPrice: Price,
+
+    @Embedded
+    val itemOption: ItemOption?,
+) {
+    companion object {
+        fun from(orderItem: OrderItemDto): OrderLine {
+            return OrderLine(
+                productId = orderItem.productId,
+                productName = ProductName.from(orderItem.name),
+                price = Price.from(orderItem.price),
+                thumbnailUrl = ThumbnailUrl.from(orderItem.thumbnailUrl),
+                quantity = Quantity.from(orderItem.quantity),
+                totalPrice = Price.from(orderItem.totalPrice),
+                itemOption = orderItem.option?.let { ItemOption.from(orderItem.option) } ?: ItemOption.default()
+            )
+        }
+    }
+}
+
+@Embeddable
+data class Quantity(
+    @Access(AccessType.FIELD)
+    val amount: Long
+) {
+    init {
+        require(amount > 0L) { ErrorMessage.INVALID_QUANTITY_AMOUNT.value }
+    }
+
+    companion object {
+        fun from(amount: Long): Quantity {
+            return Quantity(amount)
+        }
+    }
+}
+
+@Embeddable
+data class ProductName(
+    @Access(AccessType.FIELD)
+    val value: String
+) {
+    companion object {
+        fun from(name: String): ProductName {
+            return ProductName(name)
+        }
+    }
+}
+
+@Embeddable
+data class ItemOption(
+    @Access(AccessType.FIELD)
+    val color: String,
+
+    @Access(AccessType.FIELD)
+    val size: String
+) {
+    companion object {
+        fun from(option: OrderOptionDto): ItemOption {
+            return ItemOption(color = option.color, size = option.size)
+        }
+
+        fun default(): ItemOption {
+            return ItemOption(color = "", size = "FREE")
+        }
+    }
+}
+
+@Embeddable
+data class ThumbnailUrl(
+    @Access(AccessType.FIELD)
+    val value: String
+) {
+    companion object {
+        fun from(url: String): ThumbnailUrl {
+            return ThumbnailUrl(url)
+        }
+    }
+}
+
+@Embeddable
+data class Price(
+    @Access(AccessType.FIELD)
+    val amount: Long
+) {
+    init {
+        require(amount >= 0) { ErrorMessage.PRICE_AMOUNT_EXCEPTION.value }
+    }
+
+    companion object {
+        fun from(amount: Long): Price {
+            return Price(amount)
+        }
+    }
+}

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/PaymentDtos.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/PaymentDtos.kt
@@ -1,0 +1,39 @@
+package com.usktea.plainoldv2.domain.payment
+
+data class PaymentReadyRequestDto(
+    val provider: String,
+    val orderItems: List<OrderItemDto>
+)
+
+data class PaymentReadyResponseDto(
+    val paymentProvider: String,
+    val prePaymentId: Long,
+    val partnerOrderId: String,
+    val redirectUrl: String
+)
+
+data class OrderItemDto(
+    val productId: Long,
+    val price: Long,
+    val name: String,
+    val thumbnailUrl: String,
+    val shippingFee: Long,
+    val freeShippingAmount: Long,
+    val quantity: Long,
+    val totalPrice: Long,
+    val option: OrderOptionDto?
+)
+
+data class OrderOptionDto(
+    val size: String,
+    val color: String
+)
+
+data class KakaopayReadyResponse(
+    val tid: String,
+    val next_redirect_pc_url: String
+)
+
+data class KakaopayApproveResponse(
+    val aid: String
+)

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/PaymentDtos.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/PaymentDtos.kt
@@ -12,6 +12,28 @@ data class PaymentReadyResponseDto(
     val redirectUrl: String
 )
 
+data class PaymentApproveRequest(
+    val provider: String,
+    val pgToken: String,
+    val prePaymentId: Long,
+    val partnerOrderId: String,
+) {
+    companion object {
+        fun from(provider: String, pgToken: String, prePaymentId: Long, partnerOrderId: String): PaymentApproveRequest {
+            return PaymentApproveRequest(
+                provider = provider,
+                pgToken = pgToken,
+                prePaymentId = prePaymentId,
+                partnerOrderId = partnerOrderId
+            )
+        }
+    }
+}
+
+data class PaymentApproveResultDto(
+    val approveCode: String
+)
+
 data class OrderItemDto(
     val productId: Long,
     val price: Long,

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/PrePayment.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/PrePayment.kt
@@ -1,0 +1,27 @@
+package com.usktea.plainoldv2.domain.payment
+
+import com.usktea.plainoldv2.support.BaseEntity
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+
+@Entity
+class PrePayment(
+    id: Long = 0L,
+
+    val userId: Long,
+
+    val tid: String,
+
+    @ElementCollection
+    val orderItems: List<OrderLine>,
+
+    @Enumerated(EnumType.STRING)
+    val status: PrePaymentStatus = PrePaymentStatus.UNUSED
+) : BaseEntity()
+
+
+enum class PrePaymentStatus{
+    UNUSED, USED
+}

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/PrePayment.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/PrePayment.kt
@@ -19,9 +19,12 @@ class PrePayment(
 
     @Enumerated(EnumType.STRING)
     val status: PrePaymentStatus = PrePaymentStatus.UNUSED
-) : BaseEntity()
-
+) : BaseEntity() {
+    fun isUnused(): Boolean {
+        return this.status == PrePaymentStatus.UNUSED
+    }
+}
 
 enum class PrePaymentStatus{
-    UNUSED, USED
+    UNUSED, USED, FAILED
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/application/KakaopayService.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/application/KakaopayService.kt
@@ -1,0 +1,90 @@
+package com.usktea.plainoldv2.domain.payment.application
+
+import com.usktea.plainoldv2.domain.payment.*
+import com.usktea.plainoldv2.domain.payment.repository.PrePaymentRepository
+import com.usktea.plainoldv2.domain.user.User
+import com.usktea.plainoldv2.domain.user.Username
+import com.usktea.plainoldv2.domain.user.repository.UserRepository
+import com.usktea.plainoldv2.exception.UserNotExistsException
+import com.usktea.plainoldv2.properties.KakaopayProperties
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.MultiValueMap
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBody
+import java.time.LocalDateTime
+
+@Service
+class KakaopayService(
+    val properties: KakaopayProperties,
+    val paymentOrderAmountService: PaymentOrderAmountService,
+    val prePaymentRepository: PrePaymentRepository,
+    val userRepository: UserRepository,
+    val client: WebClient
+) : PaymentService {
+    override suspend fun ready(
+        username: Username,
+        orderItems: List<OrderItemDto>
+    ): PaymentReadyResponseDto {
+        val user = userRepository.findByUsernameOrNull(username) ?: throw UserNotExistsException()
+        val partnerOrderId = getPartnerOrderId()
+
+        val response = client.post()
+            .uri(properties.readyUri)
+            .header("Authorization", "KakaoAK ${properties.adminKey}")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .bodyValue(readyRequest(user, partnerOrderId, orderItems))
+            .retrieve()
+            .awaitBody<KakaopayReadyResponse>()
+
+        val prePayment = PrePayment(
+            userId = user.id,
+            tid = response.tid,
+            orderItems = orderItems.map { OrderLine.from(it) }
+        ).also { prePaymentRepository.save(it) }
+
+        return PaymentReadyResponseDto(
+            paymentProvider = properties.paymentProvider,
+            prePaymentId = prePayment.id,
+            partnerOrderId = partnerOrderId,
+            redirectUrl = response.next_redirect_pc_url
+        )
+    }
+
+    private fun readyRequest(
+        user: User,
+        partnerOrderId: String,
+        orderItems: List<OrderItemDto>
+    ): MultiValueMap<String, String> {
+        val formData = LinkedMultiValueMap<String, String>()
+        val orderAmount = paymentOrderAmountService.calculate(orderItems)
+
+        formData["cid"] = properties.cid
+        formData["partner_order_id"] = partnerOrderId
+        formData["partner_user_id"] = user.id.toString()
+        formData["item_name"] = getItemName(orderItems)
+        formData["quantity"] = orderItems.size.toString()
+        formData["total_amount"] = orderAmount.toString()
+        formData["tax_free_amount"] = properties.texFreeAmount
+        formData["approval_url"] = properties.approvalUrl
+        formData["cancel_url"] = properties.cancelUrl
+        formData["fail_url"] = properties.failUrl
+
+        return formData
+    }
+
+    private fun getItemName(orderItems: List<OrderItemDto>): String {
+        val itemName = orderItems[0].name
+
+        if (orderItems.size > 1) {
+            return "$itemName 외 상품 (${orderItems.size})개"
+        }
+
+        return itemName
+    }
+
+    private fun getPartnerOrderId(): String {
+        return LocalDateTime.now().toString()
+    }
+}

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/application/PaymentOrderAmountService.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/application/PaymentOrderAmountService.kt
@@ -1,0 +1,23 @@
+package com.usktea.plainoldv2.domain.payment.application
+
+import com.usktea.plainoldv2.domain.payment.OrderItemDto
+import org.springframework.stereotype.Service
+
+@Service
+class PaymentOrderAmountService {
+    fun calculate(orderItems: List<OrderItemDto>): Int {
+        return getTotalAmount(orderItems)
+    }
+
+    private fun getTotalAmount(orderItems: List<OrderItemDto>): Int {
+        val total = orderItems.sumOf { it.totalPrice }
+        val largestShippingFee = orderItems.maxOfOrNull { it.shippingFee } ?: 0
+        val largestFreeShippingAmount = orderItems.maxOfOrNull { it.freeShippingAmount } ?: 0
+
+        if (total > largestFreeShippingAmount) {
+            return total.toInt()
+        }
+
+        return (total + largestShippingFee).toInt()
+    }
+}

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/application/PaymentService.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/application/PaymentService.kt
@@ -1,0 +1,9 @@
+package com.usktea.plainoldv2.domain.payment.application
+
+import com.usktea.plainoldv2.domain.payment.OrderItemDto
+import com.usktea.plainoldv2.domain.payment.PaymentReadyResponseDto
+import com.usktea.plainoldv2.domain.user.Username
+
+interface PaymentService {
+    suspend fun ready(username: Username, orderItems: List<OrderItemDto>): PaymentReadyResponseDto
+}

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/application/PaymentService.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/application/PaymentService.kt
@@ -1,9 +1,11 @@
 package com.usktea.plainoldv2.domain.payment.application
 
 import com.usktea.plainoldv2.domain.payment.OrderItemDto
+import com.usktea.plainoldv2.domain.payment.PaymentApproveRequest
 import com.usktea.plainoldv2.domain.payment.PaymentReadyResponseDto
 import com.usktea.plainoldv2.domain.user.Username
 
 interface PaymentService {
     suspend fun ready(username: Username, orderItems: List<OrderItemDto>): PaymentReadyResponseDto
+    suspend fun approve(username: Username, paymentApproveRequest: PaymentApproveRequest): String
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/application/PaymentServiceFactory.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/application/PaymentServiceFactory.kt
@@ -1,0 +1,9 @@
+package com.usktea.plainoldv2.domain.payment.application
+
+data class PaymentServiceFactory(
+    private val services: MutableMap<String, PaymentService>
+) {
+    operator fun get(provider: String): PaymentService? {
+        return services[provider]
+    }
+}

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/repository/PrePaymentRepository.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/repository/PrePaymentRepository.kt
@@ -1,0 +1,29 @@
+package com.usktea.plainoldv2.domain.payment.repository
+
+import com.linecorp.kotlinjdsl.spring.data.reactive.query.SpringDataHibernateMutinyReactiveQueryFactory
+import com.usktea.plainoldv2.domain.payment.PrePayment
+import com.usktea.plainoldv2.support.BaseRepository
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import org.hibernate.reactive.mutiny.Mutiny.SessionFactory
+import org.springframework.stereotype.Repository
+
+@Repository
+class PrePaymentRepository(
+    val sessionFactory: SessionFactory,
+    val queryFactory: SpringDataHibernateMutinyReactiveQueryFactory
+) : BaseRepository<PrePayment> {
+    override suspend fun findAll(): List<PrePayment> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deleteAll() {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun save(entity: PrePayment): PrePayment {
+        return entity.also {
+            sessionFactory.withSession { session -> session.persist(it).flatMap { session.flush() } }
+                .awaitSuspending()
+        }
+    }
+}

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/repository/PrePaymentRepository.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/payment/repository/PrePaymentRepository.kt
@@ -1,7 +1,11 @@
 package com.usktea.plainoldv2.domain.payment.repository
 
+import com.linecorp.kotlinjdsl.querydsl.expression.col
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.SpringDataHibernateMutinyReactiveQueryFactory
+import com.linecorp.kotlinjdsl.spring.data.reactive.query.singleQuery
+import com.linecorp.kotlinjdsl.spring.data.reactive.query.updateQuery
 import com.usktea.plainoldv2.domain.payment.PrePayment
+import com.usktea.plainoldv2.domain.payment.PrePaymentStatus
 import com.usktea.plainoldv2.support.BaseRepository
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import org.hibernate.reactive.mutiny.Mutiny.SessionFactory
@@ -24,6 +28,25 @@ class PrePaymentRepository(
         return entity.also {
             sessionFactory.withSession { session -> session.persist(it).flatMap { session.flush() } }
                 .awaitSuspending()
+        }
+    }
+
+    suspend fun findByIdOrNull(id: Long): PrePayment? {
+        try {
+            return queryFactory.singleQuery<PrePayment> {
+                select(entity(PrePayment::class))
+                from(entity(PrePayment::class))
+                where(col(PrePayment::id).equal(id))
+            }
+        } catch (exception: Exception) {
+            return null
+        }
+    }
+
+    suspend fun updateStatus(id: Long, status: PrePaymentStatus) {
+        queryFactory.updateQuery<PrePayment> {
+            where(col(PrePayment::id).equal(id))
+            setParams(col(PrePayment::status) to status)
         }
     }
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/exception/ErrorMessage.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/exception/ErrorMessage.kt
@@ -22,5 +22,8 @@ enum class ErrorMessage(
     INVALID_ADDRESS("정확하지 않은 주소입니다"),
     USER_NOT_EXISTS("사용자 정보를 찾을 수 없습니다"),
     INVALID_ORDER_ITEM("정확하지 않은 상품 정보입니다"),
-    PAYMENT_PROVIDER_NOT_FOUND("Payment Provider를 가져오지 못 했습니다")
+    PAYMENT_PROVIDER_NOT_FOUND("Payment Provider를 가져오지 못 했습니다"),
+    PREPAYMENT_NOT_EXISTS("PrePayment 정보를 찾을 수 없습니다"),
+    KAKAOPAY_READY("카카오페이 서버에 결제 준비 요청 진행 중 에러가 발생했습니다"),
+    KAKAOPAY_APPROVE("카카오페이 서버에서 결제 승인 요청 진행 중 에러가 발생했습니다")
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/exception/ErrorMessage.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/exception/ErrorMessage.kt
@@ -21,5 +21,6 @@ enum class ErrorMessage(
     INVALID_ZIPCODE("정확하지 않은 우편번호입니다"),
     INVALID_ADDRESS("정확하지 않은 주소입니다"),
     USER_NOT_EXISTS("사용자 정보를 찾을 수 없습니다"),
-    INVALID_ORDER_ITEM("정확하지 않은 상품 정보입니다")
+    INVALID_ORDER_ITEM("정확하지 않은 상품 정보입니다"),
+    PAYMENT_PROVIDER_NOT_FOUND("Payment Provider를 가져오지 못 했습니다")
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/exception/Exceptions.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/exception/Exceptions.kt
@@ -23,3 +23,6 @@ class InvalidAddressException: GlobalException(errorMessage = ErrorMessage.INVAL
 class UserNotExistsException: GlobalException(errorMessage = ErrorMessage.USER_NOT_EXISTS.value)
 class InvalidOrderItemException: GlobalException(errorMessage = ErrorMessage.INVALID_ORDER_ITEM.value)
 class PaymentProviderNotFoundException: GlobalException(errorMessage = ErrorMessage.PAYMENT_PROVIDER_NOT_FOUND.value)
+class PrePaymentNotExistsException: GlobalException(errorMessage = ErrorMessage.PREPAYMENT_NOT_EXISTS.value)
+class KakaopayReadyException: GlobalException(errorMessage = ErrorMessage.KAKAOPAY_READY.value)
+class KakaopayApproveException: GlobalException(errorMessage = ErrorMessage.KAKAOPAY_APPROVE.value)

--- a/library/src/main/kotlin/com/usktea/plainoldv2/exception/Exceptions.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/exception/Exceptions.kt
@@ -22,3 +22,4 @@ class InvalidZipCodeException: GlobalException(errorMessage = ErrorMessage.INVAL
 class InvalidAddressException: GlobalException(errorMessage = ErrorMessage.INVALID_ADDRESS.value)
 class UserNotExistsException: GlobalException(errorMessage = ErrorMessage.USER_NOT_EXISTS.value)
 class InvalidOrderItemException: GlobalException(errorMessage = ErrorMessage.INVALID_ORDER_ITEM.value)
+class PaymentProviderNotFoundException: GlobalException(errorMessage = ErrorMessage.PAYMENT_PROVIDER_NOT_FOUND.value)

--- a/library/src/main/kotlin/com/usktea/plainoldv2/properties/KakaopayProperties.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/properties/KakaopayProperties.kt
@@ -1,0 +1,16 @@
+package com.usktea.plainoldv2.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "kakao")
+data class KakaopayProperties(
+    val cid: String,
+    val adminKey: String,
+    val readyUri: String,
+    val approvalUrl: String,
+    val cancelUrl: String,
+    val failUrl: String,
+    val texFreeAmount: String,
+    val paymentProvider: String,
+    val approveUri: String
+)

--- a/library/src/test/kotlin/com/usktea/plainoldv2/PaymentFixtures.kt
+++ b/library/src/test/kotlin/com/usktea/plainoldv2/PaymentFixtures.kt
@@ -1,0 +1,17 @@
+package com.usktea.plainoldv2
+
+import com.usktea.plainoldv2.domain.payment.OrderItemDto
+
+fun createOrderItems(amount: Long, shippingFee: Long, freeShippingAmount: Long): List<OrderItemDto> {
+    return listOf(OrderItemDto(
+        productId = 1L,
+        price = amount,
+        name = "T-Shirts",
+        thumbnailUrl = "1",
+        shippingFee = shippingFee,
+        freeShippingAmount = freeShippingAmount,
+        quantity = 1,
+        totalPrice = amount,
+        option = null
+    ))
+}

--- a/library/src/test/kotlin/com/usktea/plainoldv2/domain/payment/application/PaymentOrderAmountServiceTest.kt
+++ b/library/src/test/kotlin/com/usktea/plainoldv2/domain/payment/application/PaymentOrderAmountServiceTest.kt
@@ -1,0 +1,29 @@
+package com.usktea.plainoldv2.domain.payment.application
+
+import com.usktea.plainoldv2.createOrderItems
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.springframework.test.context.ActiveProfiles
+
+@ActiveProfiles("test")
+class PaymentOrderAmountServiceTest {
+    private val paymentOrderAmountService = PaymentOrderAmountService()
+
+    @Test
+    fun `주문 금액이 무료 배송 금액보다 큰 경우 배송 금액을 추가하지 않는다`() {
+        val orderItems = createOrderItems(amount = 50_000, shippingFee = 10_000, freeShippingAmount = 30_000)
+
+        val amount = paymentOrderAmountService.calculate(orderItems)
+
+        amount shouldBe 50_000
+    }
+
+    @Test
+    fun `주문 금액이 무료 배송 금액보다 적은 경우 배송 금액을 추가한다`() {
+        val orderItems = createOrderItems(amount = 20_000, shippingFee = 10_000, freeShippingAmount = 30_000)
+
+        val amount = paymentOrderAmountService.calculate(orderItems)
+
+        amount shouldBe 20_000 + 10_000
+    }
+}


### PR DESCRIPTION
카카오페이 결제 요청이 오면 카카오페이 서버에 Ready 요청을 날리는 로직 구현.
Ready 요청을 날리고 응답을 받으면 추후 approve에 사용될 PrePayment 객체를 생성해 userId, tid, 상품 정보를 저장함.