### PR TITLE
사용자 장바구니의 상품은 변경될 수 있어야 한다

### DIFF
--- a/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/cart/CartHandler.kt
+++ b/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/cart/CartHandler.kt
@@ -30,4 +30,14 @@ class CartHandler(
 
         return ok().contentType(MediaType.APPLICATION_JSON).bodyValueAndAwait(AddCartItemResult(counts))
     }
+
+    suspend fun updateItems(request: ServerRequest): ServerResponse {
+        val username = request.attributeOrNull("username") as? Username ?: throw RequestAttributeNotFoundException()
+        val updateCartItemRequest =
+            request.awaitBodyOrNull<UpdateCartItemRequest>() ?: throw RequestBodyNotFoundException()
+        val cartItems = updateCartItemRequest.items.map { CartItem.from(it) }
+        val updatedIds = cartService.updateItems(username = username, cartItems = cartItems)
+
+        return ok().contentType(MediaType.APPLICATION_JSON).bodyValueAndAwait(UpdateCartItemResult(updatedIds))
+    }
 }

--- a/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/cart/CartRouter.kt
+++ b/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/cart/CartRouter.kt
@@ -13,6 +13,7 @@ class CartRouter {
         path(context).nest {
             GET("", handler::getItems)
             POST("", handler::addItems)
+            PATCH("", handler::updateItems)
         }
     }
 }

--- a/application/src/test/kotlin/com/usktea/plainoldv2/application/CartFixtures.kt
+++ b/application/src/test/kotlin/com/usktea/plainoldv2/application/CartFixtures.kt
@@ -37,3 +37,23 @@ fun createAddCartItemRequest(): AddCartItemRequest {
         )
     )
 }
+
+fun createUpdateCartItemRequest(): UpdateCartItemRequest {
+    return UpdateCartItemRequest(
+        items = listOf(
+            CartItemDto(
+                productId = 1L,
+                price = 1L,
+                name = "T-Shirts",
+                thumbnailUrl = "1",
+                shippingFee = 1L,
+                freeShippingAmount = 1L,
+                quantity = 1L,
+                option = ItemOptionDto(
+                    color = "RED",
+                    size = "XL"
+                )
+            )
+        )
+    )
+}

--- a/application/src/test/kotlin/com/usktea/plainoldv2/application/endpoints/cart/CartHandlerTest.kt
+++ b/application/src/test/kotlin/com/usktea/plainoldv2/application/endpoints/cart/CartHandlerTest.kt
@@ -4,6 +4,7 @@ import com.ninjasquad.springmockk.MockkBean
 import com.ninjasquad.springmockk.SpykBean
 import com.usktea.plainoldv2.application.createAddCartItemRequest
 import com.usktea.plainoldv2.application.createCartItem
+import com.usktea.plainoldv2.application.createUpdateCartItemRequest
 import com.usktea.plainoldv2.application.createUsername
 import com.usktea.plainoldv2.domain.cart.CartItem
 import com.usktea.plainoldv2.domain.cart.application.CartService
@@ -18,6 +19,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 
 const val USERNAME = "tjrxo1234@gmail.com"
+const val PRODUCT_ID = 1L
 
 @ActiveProfiles("test")
 @WebFluxTest(CartRouter::class, CartHandler::class)
@@ -66,5 +68,24 @@ class CartHandlerTest {
             .expectStatus().isOk
             .expectBody()
             .jsonPath("$.counts").isEqualTo(1)
+    }
+
+    @Test
+    fun `사용자 카트의 아이템을 수정한다`() {
+        val username = createUsername(USERNAME)
+        val token = jwtUtil.encode(USERNAME)
+        val updateCartItemRequest = createUpdateCartItemRequest()
+
+        coEvery { cartService.updateItems(username, any()) } returns listOf(PRODUCT_ID)
+
+        client.mutateWith(csrf()).mutateWith(mockUser())
+            .patch()
+            .uri("/carts")
+            .header("Authorization", "Bearer $token")
+            .bodyValue(updateCartItemRequest)
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$.updated").isNotEmpty
     }
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/cart/CartDtos.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/cart/CartDtos.kt
@@ -51,3 +51,11 @@ data class AddCartItemRequest(
 data class AddCartItemResult(
     val counts: Int
 )
+
+data class UpdateCartItemRequest(
+    val items: List<CartItemDto>
+)
+
+data class UpdateCartItemResult(
+    val updated: List<Long>
+)

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/cart/CartItem.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/cart/CartItem.kt
@@ -50,6 +50,19 @@ data class CartItem(
         )
     }
 
+    fun updateQuantity(quantity: Quantity): CartItem {
+        return CartItem(
+            productId = productId,
+            price = price,
+            productName = productName,
+            thumbnailUrl = thumbnailUrl,
+            shippingFee = shippingFee,
+            freeShippingAmount = freeShippingAmount,
+            quantity = quantity,
+            itemOption = itemOption
+        )
+    }
+
     companion object {
         fun from(cartItemDto: CartItemDto): CartItem {
             return CartItem(

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/cart/application/UpdateCartItemUseCase.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/cart/application/UpdateCartItemUseCase.kt
@@ -1,0 +1,8 @@
+package com.usktea.plainoldv2.domain.cart.application
+
+import com.usktea.plainoldv2.domain.cart.CartItem
+import com.usktea.plainoldv2.domain.user.Username
+
+interface UpdateCartItemUseCase {
+    suspend fun updateItems(username: Username, cartItems: List<CartItem>): List<Long>
+}

--- a/library/src/main/kotlin/com/usktea/plainoldv2/exception/ErrorMessage.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/exception/ErrorMessage.kt
@@ -25,5 +25,7 @@ enum class ErrorMessage(
     PAYMENT_PROVIDER_NOT_FOUND("Payment Provider를 가져오지 못 했습니다"),
     PREPAYMENT_NOT_EXISTS("PrePayment 정보를 찾을 수 없습니다"),
     KAKAOPAY_READY("카카오페이 서버에 결제 준비 요청 진행 중 에러가 발생했습니다"),
-    KAKAOPAY_APPROVE("카카오페이 서버에서 결제 승인 요청 진행 중 에러가 발생했습니다")
+    KAKAOPAY_APPROVE("카카오페이 서버에서 결제 승인 요청 진행 중 에러가 발생했습니다"),
+    CART_NOT_FOUND("사용자 장바구니 정보를 찾을 수 없습니다"),
+    CART_ITEM_NOT_FOUND("사용자 장바구니에서 상품을 찾을 수 없습니다")
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/exception/Exceptions.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/exception/Exceptions.kt
@@ -26,3 +26,5 @@ class PaymentProviderNotFoundException: GlobalException(errorMessage = ErrorMess
 class PrePaymentNotExistsException: GlobalException(errorMessage = ErrorMessage.PREPAYMENT_NOT_EXISTS.value)
 class KakaopayReadyException: GlobalException(errorMessage = ErrorMessage.KAKAOPAY_READY.value)
 class KakaopayApproveException: GlobalException(errorMessage = ErrorMessage.KAKAOPAY_APPROVE.value)
+class CartItemNotFoundException: GlobalException(errorMessage = ErrorMessage.CART_ITEM_NOT_FOUND.value)
+class CartNotFoundException: GlobalException(errorMessage = ErrorMessage.CART_NOT_FOUND.value)

--- a/library/src/test/kotlin/com/usktea/plainoldv2/CartFixtures.kt
+++ b/library/src/test/kotlin/com/usktea/plainoldv2/CartFixtures.kt
@@ -2,15 +2,15 @@ package com.usktea.plainoldv2
 
 import com.usktea.plainoldv2.domain.cart.*
 
-fun createCartItem(): CartItem {
+fun createCartItem(productId: Long = 1L, quantity: Long = 1L): CartItem {
     return CartItem(
-        productId = 1L,
+        productId = productId,
         price = Price(1L),
         productName = ProductName("T-Shirts"),
         thumbnailUrl = ThumbnailUrl("1"),
         shippingFee = Price(1L),
         freeShippingAmount = Price(1L),
-        quantity = Quantity(1L),
+        quantity = Quantity(quantity),
         itemOption = ItemOption(
             size = Size.M,
             color = "RED"

--- a/library/src/test/kotlin/com/usktea/plainoldv2/domain/cart/CartItemTest.kt
+++ b/library/src/test/kotlin/com/usktea/plainoldv2/domain/cart/CartItemTest.kt
@@ -59,4 +59,26 @@ class CartItemTest {
 
         increased.quantity shouldBe Quantity(3L)
     }
+
+    @Test
+    fun `수량이 변경된 CartItem을 반환한다`() {
+        val cartItem = CartItem(
+            productId = 1L,
+            price = Price(1L),
+            productName = ProductName("T-shirts"),
+            thumbnailUrl = ThumbnailUrl("1"),
+            shippingFee = Price(1L),
+            freeShippingAmount = Price(1L),
+            quantity = Quantity(1L),
+            itemOption = ItemOption(
+                color = "RED",
+                size = Size.XL
+            )
+        )
+
+        val two = Quantity(2L)
+        val updated = cartItem.updateQuantity(two)
+
+        updated.quantity shouldBe two
+    }
 }

--- a/library/src/test/kotlin/com/usktea/plainoldv2/domain/cart/CartTest.kt
+++ b/library/src/test/kotlin/com/usktea/plainoldv2/domain/cart/CartTest.kt
@@ -42,6 +42,26 @@ class CartTest {
         cart.countItems() shouldBe 1
         cart.firstItem().quantity shouldBe Quantity(2L)
     }
+
+    @Test
+    fun `카트에 있는 상품의 수량을 변경할 수 있다`() {
+        val origin = createCartItem(
+            productId = 1L,
+            quantity = 1L
+        )
+        val cart = createCart(USER_ID, mutableListOf(origin))
+        val other = createCartItem(
+            productId = 1L,
+            quantity = 3L
+        )
+
+        cart.firstItem().quantity shouldBe Quantity(1L)
+
+        val updatedIds = cart.updateItems(items = listOf(other))
+
+        updatedIds shouldBe listOf(1L)
+        cart.firstItem().quantity shouldBe Quantity(3L)
+    }
 }
 
 


### PR DESCRIPTION
사용자 요청으로 장바구니의 상품 수량은 변경된다.
기존 Repository에 있는 서비스 로직을 서비스 레이어로 옮김.
확장함수 updateTo를 사용해 엔티티 속성을 변경시켰음.