### PR TITLE
사용자는 장바구니 상품을 제거할 수 있어야 한다

### DIFF
--- a/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/cart/CartHandler.kt
+++ b/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/cart/CartHandler.kt
@@ -40,4 +40,14 @@ class CartHandler(
 
         return ok().contentType(MediaType.APPLICATION_JSON).bodyValueAndAwait(UpdateCartItemResult(updatedIds))
     }
+
+    suspend fun deleteItems(request: ServerRequest): ServerResponse {
+        val username = request.attributeOrNull("username") as? Username ?: throw RequestAttributeNotFoundException()
+        val deleteCartItemRequest =
+            request.awaitBodyOrNull<DeleteCartItemRequest>() ?: throw RequestBodyNotFoundException()
+        val cartItems = deleteCartItemRequest.items.map { CartItem.from(it) }
+        val deletedIds = cartService.deleteItems(username = username, cartItems = cartItems)
+
+        return ok().contentType(MediaType.APPLICATION_JSON).bodyValueAndAwait(DeleteCartItemResult(deletedIds))
+    }
 }

--- a/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/cart/CartRouter.kt
+++ b/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/cart/CartRouter.kt
@@ -14,6 +14,7 @@ class CartRouter {
             GET("", handler::getItems)
             POST("", handler::addItems)
             PATCH("", handler::updateItems)
+            POST("/delete", handler::deleteItems)
         }
     }
 }

--- a/application/src/test/kotlin/com/usktea/plainoldv2/application/CartFixtures.kt
+++ b/application/src/test/kotlin/com/usktea/plainoldv2/application/CartFixtures.kt
@@ -57,3 +57,23 @@ fun createUpdateCartItemRequest(): UpdateCartItemRequest {
         )
     )
 }
+
+fun createDeleteCartItemRequest(): DeleteCartItemRequest {
+    return DeleteCartItemRequest(
+        items = listOf(
+            CartItemDto(
+                productId = 1L,
+                price = 1L,
+                name = "T-Shirts",
+                thumbnailUrl = "1",
+                shippingFee = 1L,
+                freeShippingAmount = 1L,
+                quantity = 1L,
+                option = ItemOptionDto(
+                    color = "RED",
+                    size = "XL"
+                )
+            )
+        )
+    )
+}

--- a/application/src/test/kotlin/com/usktea/plainoldv2/application/endpoints/cart/CartHandlerTest.kt
+++ b/application/src/test/kotlin/com/usktea/plainoldv2/application/endpoints/cart/CartHandlerTest.kt
@@ -2,12 +2,9 @@ package com.usktea.plainoldv2.application.endpoints.cart
 
 import com.ninjasquad.springmockk.MockkBean
 import com.ninjasquad.springmockk.SpykBean
-import com.usktea.plainoldv2.application.createAddCartItemRequest
-import com.usktea.plainoldv2.application.createCartItem
-import com.usktea.plainoldv2.application.createUpdateCartItemRequest
-import com.usktea.plainoldv2.application.createUsername
-import com.usktea.plainoldv2.domain.cart.CartItem
+import com.usktea.plainoldv2.application.*
 import com.usktea.plainoldv2.domain.cart.application.CartService
+import com.usktea.plainoldv2.domain.user.Username
 import com.usktea.plainoldv2.utils.JwtUtil
 import io.mockk.coEvery
 import org.junit.jupiter.api.Test
@@ -87,5 +84,24 @@ class CartHandlerTest {
             .expectStatus().isOk
             .expectBody()
             .jsonPath("$.updated").isNotEmpty
+    }
+
+    @Test
+    fun `사용자 카트의 아이템을 제거한다`() {
+        val username = Username(USERNAME)
+        val token = jwtUtil.encode(USERNAME)
+        val deleteCartItemRequest = createDeleteCartItemRequest()
+
+        coEvery { cartService.deleteItems(username, any()) } returns listOf(PRODUCT_ID)
+
+        client.mutateWith(csrf()).mutateWith(mockUser())
+            .post()
+            .uri("/carts/delete")
+            .header("Authorization", "Bearer $token")
+            .bodyValue(deleteCartItemRequest)
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$.deleted").isNotEmpty
     }
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/cart/Cart.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/cart/Cart.kt
@@ -65,6 +65,16 @@ class Cart(
         return this.cartItems.firstOrNull { it.checkIsSame(item) }
     }
 
+    fun deleteItems(items: List<CartItem>): List<Long> {
+        return items.map {
+            val found = findSameItem(it) ?: throw CartItemNotFoundException()
+
+            this.cartItems.remove(found)
+
+            found.productId
+        }
+    }
+
     companion object {
         val NULL = Cart(userId = 0L, cartItems = mutableListOf())
     }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/cart/CartDtos.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/cart/CartDtos.kt
@@ -59,3 +59,11 @@ data class UpdateCartItemRequest(
 data class UpdateCartItemResult(
     val updated: List<Long>
 )
+
+data class DeleteCartItemRequest(
+    val items: List<CartItemDto>
+)
+
+data class DeleteCartItemResult(
+    val deleted: List<Long>
+)

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/cart/application/CartService.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/cart/application/CartService.kt
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service
 class CartService(
     private val userRepository: UserRepository,
     private val cartRepository: CartRepository
-) : GetCartItemUseCase, CreateCartUseCase, AddCartItemUseCase, UpdateCartItemUseCase {
+) : GetCartItemUseCase, CreateCartUseCase, AddCartItemUseCase, UpdateCartItemUseCase, DeleteCartItemUseCase {
     override suspend fun getCartItems(username: Username): List<CartItem> {
         val user = userRepository.findByUsernameOrNull(username) ?: throw UserNotExistsException()
         val cart = cartRepository.findByUserIdOrNull(user.id) ?: Cart.NULL
@@ -54,5 +54,16 @@ class CartService(
         cartRepository.update(cart)
 
         return updatedIds
+    }
+
+    override suspend fun deleteItems(username: Username, cartItems: List<CartItem>): List<Long> {
+        val user = userRepository.findByUsernameOrNull(username) ?: throw UserNotExistsException()
+        val cart = cartRepository.findByUserIdOrNull(user.id) ?: throw CartNotFoundException()
+
+        val deletedIds = cart.deleteItems(items = cartItems)
+
+        cartRepository.update(cart)
+
+        return deletedIds
     }
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/cart/application/DeleteCartItemUseCase.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/cart/application/DeleteCartItemUseCase.kt
@@ -1,0 +1,8 @@
+package com.usktea.plainoldv2.domain.cart.application
+
+import com.usktea.plainoldv2.domain.cart.CartItem
+import com.usktea.plainoldv2.domain.user.Username
+
+interface DeleteCartItemUseCase {
+    suspend fun deleteItems(username: Username, cartItems: List<CartItem>): List<Long>
+}

--- a/library/src/test/kotlin/com/usktea/plainoldv2/domain/cart/CartTest.kt
+++ b/library/src/test/kotlin/com/usktea/plainoldv2/domain/cart/CartTest.kt
@@ -2,6 +2,7 @@ package com.usktea.plainoldv2.domain.cart
 
 import com.usktea.plainoldv2.createCart
 import com.usktea.plainoldv2.createCartItem
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -61,6 +62,20 @@ class CartTest {
 
         updatedIds shouldBe listOf(1L)
         cart.firstItem().quantity shouldBe Quantity(3L)
+    }
+
+    @Test
+    fun `카트에 있는 상품을 제거할 수 있다`() {
+        val cartItem = createCartItem(
+            productId = 1L,
+            quantity = 1L
+        )
+        val cart = createCart(USER_ID, mutableListOf(cartItem))
+
+        val deletedIds = cart.deleteItems(listOf(cartItem))
+
+        deletedIds shouldBe listOf(1L)
+        cart.cartItems shouldHaveSize 0
     }
 }
 

--- a/library/src/test/kotlin/com/usktea/plainoldv2/domain/cart/application/CartServiceTest.kt
+++ b/library/src/test/kotlin/com/usktea/plainoldv2/domain/cart/application/CartServiceTest.kt
@@ -104,4 +104,24 @@ class CartServiceTest {
         updatedIds shouldHaveSize 1
         updatedIds.first() shouldBe PRODUCT_ID
     }
+
+    @Test
+    fun `사용자 카트의 상품을 제거한다`() = runTest {
+        val username = createUsername(USERNAME)
+        val password = createPassword(PASSWORD)
+        val user = createUser(username, password)
+        val cartItem = createCartItem(PRODUCT_ID)
+        val cartItems = listOf(cartItem)
+        val cart = createCart(userId = user.id, cartItems = mutableListOf(cartItem))
+
+        coEvery { userRepository.findByUsernameOrNull(username) } returns user
+        coEvery { cartRepository.findByUserIdOrNull(user.id) } returns cart
+        coEvery { cartRepository.update(cart) } returns Unit
+
+        val deletedIds = cartService.deleteItems(username = username, cartItems = cartItems)
+
+        coVerify(exactly = 1) { cartRepository.update(cart) }
+        deletedIds shouldHaveSize 1
+        deletedIds.first() shouldBe PRODUCT_ID
+    }
 }


### PR DESCRIPTION
장바구니 상품을 제거하고 다시 상품을 추가할 때 fetch되는 CartItem이 없어 예외가 발생했음. 
Cart가 없다면 Cart를 저장하게 하고 CartItem이 없다면 Cart를 업데이트 하는 방식으로 구현함.