### PR TITLE
사용자는 구입한 상품에 구매평을 남길 수 있어야 한다

### DIFF
--- a/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/review/ReviewRouter.kt
+++ b/application/src/main/kotlin/com/usktea/plainoldv2/application/endpoints/review/ReviewRouter.kt
@@ -12,6 +12,7 @@ class ReviewRouter {
     fun reviewRoutes(handler: ReviewHandler) = coRouter {
         path(context).nest {
             GET("", handler::getReviews)
+            POST("", handler::postReview)
         }
     }
 }

--- a/application/src/test/kotlin/com/usktea/plainoldv2/application/ReviewFixtures.kt
+++ b/application/src/test/kotlin/com/usktea/plainoldv2/application/ReviewFixtures.kt
@@ -19,3 +19,13 @@ fun createReview(reviewId: Long, productId: Long): Review {
         imageUrl = ImageUrl("1"),
     )
 }
+
+fun createPostReviewRequestDto(): PostReviewRequestDto {
+    return PostReviewRequestDto(
+        orderNumber = "tjrxo1234-111111",
+        productId = 1L,
+        comment = "아주 좋습니다",
+        rate = 5,
+        imageUrl = "1"
+    )
+}

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/order/Order.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/order/Order.kt
@@ -65,7 +65,13 @@ class Order(
 data class OrderNumber(
     @Column(name = "orderNumber")
     val value: String
-)
+) {
+    companion object {
+        fun from(number: String): OrderNumber {
+            return OrderNumber(number)
+        }
+    }
+}
 
 enum class OrderStatus(
     val value: String

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/order/repository/OrderRepository.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/order/repository/OrderRepository.kt
@@ -101,7 +101,7 @@ class OrderRepository(
                 )
             }.map { it.orderNumber }.toSet()
 
-            (orderNumbers - reviewsOrderNumbers).first()
+            (orderNumbers - reviewsOrderNumbers).firstOrNull()
         }
     }
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/product/ProductDtos.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/product/ProductDtos.kt
@@ -9,6 +9,7 @@ import java.time.Instant
 data class FindProductSpec(
     val categoryId: Long? = null,
     val productId: Long? = null,
+    val status: ProductStatus = ProductStatus.ON_SALE
 )
 
 data class ProductDto(

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/product/application/ProductService.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/product/application/ProductService.kt
@@ -20,13 +20,9 @@ class ProductService(
     }
 
     override suspend fun getProductDetail(productSpec: FindProductSpec): ProductDetailDto {
-        try {
-            val product = productRepository.findBySpec(productSpec)
-            val option = optionRepository.findByProductIdOrNull(productSpec.productId!!)
+        val product = productRepository.findBySpec(productSpec) ?: throw ProductNotFoundException()
+        val option = optionRepository.findByProductIdOrNull(productSpec.productId!!)
 
-            return ProductDetailDto.from(product, option)
-        } catch (exception: Exception) {
-            throw ProductNotFoundException()
-        }
+        return ProductDetailDto.from(product, option)
     }
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/product/repository/ProductRepository.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/product/repository/ProductRepository.kt
@@ -2,9 +2,7 @@ package com.usktea.plainoldv2.domain.product.repository
 
 import com.linecorp.kotlinjdsl.querydsl.expression.col
 import com.linecorp.kotlinjdsl.querydsl.where.WhereDsl
-import com.linecorp.kotlinjdsl.spring.data.reactive.query.SpringDataHibernateMutinyReactiveQueryFactory
-import com.linecorp.kotlinjdsl.spring.data.reactive.query.listQuery
-import com.linecorp.kotlinjdsl.spring.data.reactive.query.pageQuery
+import com.linecorp.kotlinjdsl.spring.data.reactive.query.*
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.singleQuery
 import com.usktea.plainoldv2.domain.category.Category
 import com.usktea.plainoldv2.domain.product.FindProductSpec
@@ -48,8 +46,8 @@ class ProductRepository(
         }
     }
 
-    suspend fun findBySpec(spec: FindProductSpec): Product {
-        return queryFactory.singleQuery<Product> {
+    suspend fun findBySpec(spec: FindProductSpec): Product? {
+        return queryFactory.singleQueryOrNull<Product> {
             select(entity(Product::class))
             from(entity(Product::class))
             where(findSpec(spec))
@@ -59,6 +57,7 @@ class ProductRepository(
     private fun WhereDsl.findSpec(spec: FindProductSpec) =
         and(
             spec.categoryId?.let { col(Product::categoryId).equal(spec.categoryId) },
-            spec.productId?.let { col(Product::id).equal(spec.productId) }
+            spec.productId?.let { col(Product::id).equal(spec.productId) },
+            col(Product::productStatus).equal(spec.status)
         )
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/Comment.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/Comment.kt
@@ -7,4 +7,10 @@ import jakarta.persistence.Embeddable
 data class Comment(
     @Column(name = "comment")
     val value: String
-)
+) {
+    companion object {
+        fun from(value: String): Comment {
+            return Comment(value)
+        }
+    }
+}

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/ImageUrl.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/ImageUrl.kt
@@ -7,4 +7,10 @@ import jakarta.persistence.Embeddable
 data class ImageUrl(
     @Column(name = "imageUIrl")
     val value: String
-)
+) {
+    companion object {
+        fun from(value: String): ImageUrl {
+            return ImageUrl(value)
+        }
+    }
+}

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/Rate.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/Rate.kt
@@ -12,4 +12,10 @@ data class Rate(
     init {
         require(value in 1..5) { ErrorMessage.INVALID_RATE.value }
     }
+
+    companion object {
+        fun from(value: Int): Rate {
+            return Rate(value)
+        }
+    }
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/Review.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/Review.kt
@@ -1,6 +1,8 @@
 package com.usktea.plainoldv2.domain.review
 
 import com.usktea.plainoldv2.domain.order.OrderNumber
+import com.usktea.plainoldv2.domain.user.Nickname
+import com.usktea.plainoldv2.domain.user.Username
 import com.usktea.plainoldv2.support.BaseEntity
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
@@ -24,8 +26,23 @@ class Review(
     val comment: Comment,
 
     @Embedded
-    val imageUrl: ImageUrl?,
-
-    ) : BaseEntity(id)
+    val imageUrl: ImageUrl?
+    ) : BaseEntity(id) {
+    companion object {
+        fun of(postReviewRequest: PostReviewRequest, username: Username, nickname: Nickname): Review {
+            return Review(
+                productId = postReviewRequest.productId,
+                orderNumber = postReviewRequest.orderNumber,
+                reviewer = Reviewer.of(
+                    username = username,
+                    nickname = nickname
+                ),
+                rate = postReviewRequest.rate,
+                comment = postReviewRequest.comment,
+                imageUrl = postReviewRequest.imageUrl
+            )
+        }
+    }
+}
 
 

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/ReviewDtos.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/ReviewDtos.kt
@@ -1,5 +1,6 @@
 package com.usktea.plainoldv2.domain.review
 
+import com.usktea.plainoldv2.domain.order.OrderNumber
 import com.usktea.plainoldv2.support.PageDto
 
 data class FindReviewSpec(
@@ -49,3 +50,35 @@ data class ReviewsDto(
     val reviews: List<ReviewDto>,
     val page: PageDto
 )
+
+data class PostReviewRequestDto(
+    val productId: Long,
+    val orderNumber: String,
+    val comment: String,
+    val rate: Int,
+    val imageUrl: String?
+)
+
+data class PostReviewResultDto(
+    val reviewId: Long
+)
+
+data class PostReviewRequest(
+    val productId: Long,
+    val orderNumber: OrderNumber,
+    val comment: Comment,
+    val rate: Rate,
+    val imageUrl: ImageUrl?
+) {
+    companion object {
+        fun from(postReviewRequestDto: PostReviewRequestDto): PostReviewRequest {
+            return PostReviewRequest(
+                productId = postReviewRequestDto.productId,
+                orderNumber = OrderNumber.from(postReviewRequestDto.orderNumber),
+                comment = Comment.from(postReviewRequestDto.comment),
+                rate = Rate.from(postReviewRequestDto.rate),
+                imageUrl = postReviewRequestDto.imageUrl?.let { ImageUrl.from(it) }
+            )
+        }
+    }
+}

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/Reviewer.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/Reviewer.kt
@@ -8,4 +8,13 @@ import jakarta.persistence.Embeddable
 data class Reviewer(
     val username: Username,
     val nickname: Nickname
-)
+) {
+    companion object {
+        fun of(username: Username, nickname: Nickname): Reviewer {
+            return Reviewer(
+                username = username,
+                nickname = nickname
+            )
+        }
+    }
+}

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/application/PostReviewUseCase.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/application/PostReviewUseCase.kt
@@ -1,0 +1,9 @@
+package com.usktea.plainoldv2.domain.review.application
+
+import com.usktea.plainoldv2.domain.review.PostReviewRequest
+import com.usktea.plainoldv2.domain.review.Review
+import com.usktea.plainoldv2.domain.user.Username
+
+interface PostReviewUseCase {
+    suspend fun postReview(username: Username, postReviewRequest: PostReviewRequest): Review
+}

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/application/ReviewService.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/application/ReviewService.kt
@@ -1,17 +1,36 @@
 package com.usktea.plainoldv2.domain.review.application
 
+import com.usktea.plainoldv2.domain.product.FindProductSpec
+import com.usktea.plainoldv2.domain.product.repository.ProductRepository
 import com.usktea.plainoldv2.domain.review.FindReviewSpec
+import com.usktea.plainoldv2.domain.review.PostReviewRequest
 import com.usktea.plainoldv2.domain.review.Review
 import com.usktea.plainoldv2.domain.review.repository.ReviewRepository
+import com.usktea.plainoldv2.domain.user.Username
+import com.usktea.plainoldv2.domain.user.repository.UserRepository
+import com.usktea.plainoldv2.exception.ProductNotFoundException
+import com.usktea.plainoldv2.exception.UserNotExistsException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 
 @Service
 class ReviewService(
-    private val reviewRepository: ReviewRepository
-): FindAllReviewByPagingUseCase {
+    private val reviewRepository: ReviewRepository,
+    private val userRepository: UserRepository,
+    private val productRepository: ProductRepository
+) : FindAllReviewByPagingUseCase, PostReviewUseCase {
     override suspend fun findAllByPaging(findReviewSpec: FindReviewSpec, pageable: Pageable): Page<Review> {
         return reviewRepository.findAllByPaging(findReviewSpec, pageable)
+    }
+
+    override suspend fun postReview(username: Username, postReviewRequest: PostReviewRequest): Review {
+        val user = userRepository.findByUsernameOrNull(username) ?: throw UserNotExistsException()
+
+        return Review.of(
+            postReviewRequest = postReviewRequest,
+            username = user.username,
+            nickname = user.nickname
+        ).also { reviewRepository.save(it) }
     }
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/repository/ReviewRepository.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/domain/review/repository/ReviewRepository.kt
@@ -4,8 +4,15 @@ import com.linecorp.kotlinjdsl.querydsl.expression.col
 import com.linecorp.kotlinjdsl.querydsl.where.WhereDsl
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.SpringDataHibernateMutinyReactiveQueryFactory
 import com.linecorp.kotlinjdsl.spring.data.reactive.query.pageQuery
+import com.linecorp.kotlinjdsl.spring.reactive.singleQueryOrNull
+import com.usktea.plainoldv2.domain.product.Product
+import com.usktea.plainoldv2.domain.product.ProductStatus
 import com.usktea.plainoldv2.domain.review.FindReviewSpec
 import com.usktea.plainoldv2.domain.review.Review
+import com.usktea.plainoldv2.exception.ProductNotFoundException
+import com.usktea.plainoldv2.exception.ReviewAlreadyWritten
+import com.usktea.plainoldv2.support.BaseRepository
+import io.smallrye.mutiny.coroutines.awaitSuspending
 import org.hibernate.reactive.mutiny.Mutiny.SessionFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -15,7 +22,7 @@ import org.springframework.stereotype.Repository
 class ReviewRepository(
     private val sessionFactory: SessionFactory,
     private val queryFactory: SpringDataHibernateMutinyReactiveQueryFactory
-) {
+) : BaseRepository<Review> {
     suspend fun findAllByPaging(findReviewSpec: FindReviewSpec, pageable: Pageable): Page<Review> {
         return queryFactory.pageQuery(pageable) {
             select(entity(Review::class))
@@ -29,4 +36,46 @@ class ReviewRepository(
             col(Review::productId).equal(spec.productId),
             spec.photoReviews.takeIf { it }?.let { col(Review::imageUrl).isNotNull() }
         )
+
+    override suspend fun findAll(): List<Review> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deleteAll() {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun save(entity: Review): Review {
+        return entity.also {
+            queryFactory.withFactory { factory ->
+                factory.singleQueryOrNull<Product> {
+                    select(entity(Product::class))
+                    from(entity(Product::class))
+                    whereAnd(
+                        col(Product::id).equal(entity.productId),
+                        col(Product::productStatus).equal(ProductStatus.ON_SALE)
+                    )
+                } ?: throw ProductNotFoundException()
+
+                val found = factory.singleQueryOrNull<Review> {
+                    select(entity(Review::class))
+                    from(entity(Review::class))
+                    whereAnd(
+                        col(Review::orderNumber).equal(entity.orderNumber),
+                        col(Review::productId).equal(entity.productId)
+                    )
+                }
+
+                if (found != null) {
+                    throw ReviewAlreadyWritten()
+                }
+
+                sessionFactory.withSession { session ->
+                    session.persist(entity).flatMap { session.flush() }
+                }.awaitSuspending()
+            }
+
+            it
+        }
+    }
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/exception/ErrorMessage.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/exception/ErrorMessage.kt
@@ -31,5 +31,6 @@ enum class ErrorMessage(
     COOKIE_NOT_FOUND("쿠키 정보를 찾을 수 없습니다"),
     REFRESH_TOKEN_NOT_FOUND("RefreshToken 정보를 찾을 수 없습니다"),
     INVALID_RATE("정확하지 않은 Rate 값입니다"),
-    ORDER_CAN_WRITE_REVIEW_NOT_FOUND("구매평 작성이 가능한 주문기록을 찾을 수 없습니다")
+    ORDER_CAN_WRITE_REVIEW_NOT_FOUND("구매평 작성이 가능한 주문기록을 찾을 수 없습니다"),
+    REVIEW_ALREADY_WRITTEN("이미 작성한 구매평이 있습니다")
 }

--- a/library/src/main/kotlin/com/usktea/plainoldv2/exception/Exceptions.kt
+++ b/library/src/main/kotlin/com/usktea/plainoldv2/exception/Exceptions.kt
@@ -31,4 +31,5 @@ class CartNotFoundException : GlobalException(errorMessage = ErrorMessage.CART_N
 class CookieNotFoundException : GlobalException(errorMessage = ErrorMessage.COOKIE_NOT_FOUND.value)
 class RefreshTokenNotFoundException : GlobalException(errorMessage = ErrorMessage.REFRESH_TOKEN_NOT_FOUND.value)
 class OrderCanWriteReviewNotFoundException :
-    GlobalException(errorMessage = ErrorMessage.ORDER_CAN_WRITE_REVIEW_NOT_FOUND.value)
+    GlobalException(httpStatus = HttpStatus.NOT_FOUND ,errorMessage = ErrorMessage.ORDER_CAN_WRITE_REVIEW_NOT_FOUND.value)
+class ReviewAlreadyWritten : GlobalException(errorMessage = ErrorMessage.REVIEW_ALREADY_WRITTEN.value)

--- a/library/src/test/kotlin/com/usktea/plainoldv2/ReviewFixtures.kt
+++ b/library/src/test/kotlin/com/usktea/plainoldv2/ReviewFixtures.kt
@@ -14,17 +14,30 @@ fun createFindReviewSpec(
     )
 }
 
-fun createReview(productId: Long): Review {
+fun createReview(productId: Long, orderNumber: String = "tjrxo1234-111111"): Review {
     return Review(
         id = 1L,
         productId = productId,
-        orderNumber = OrderNumber("11"),
+        orderNumber = OrderNumber(orderNumber),
         reviewer = Reviewer(
             username = Username("tjrxo1234@gmail.com"),
             nickname = Nickname("김뚜루")
         ),
         rate = Rate(5),
         comment = Comment("매우 좋습니다"),
+        imageUrl = ImageUrl("1")
+    )
+}
+
+fun createPostReviewRequest(
+    orderNumber: String = "tjrxo1234-111111",
+    productId: Long = 1L
+): PostReviewRequest {
+    return PostReviewRequest(
+        productId = productId,
+        orderNumber = OrderNumber(orderNumber),
+        comment = Comment("너무 좋아요"),
+        rate = Rate(5),
         imageUrl = ImageUrl("1")
     )
 }

--- a/library/src/test/kotlin/com/usktea/plainoldv2/domain/review/application/ReviewServiceTest.kt
+++ b/library/src/test/kotlin/com/usktea/plainoldv2/domain/review/application/ReviewServiceTest.kt
@@ -1,9 +1,13 @@
 package com.usktea.plainoldv2.domain.review.application
 
-import com.usktea.plainoldv2.createFindReviewSpec
-import com.usktea.plainoldv2.createReview
+import com.usktea.plainoldv2.*
+import com.usktea.plainoldv2.domain.cart.application.PASSWORD
+import com.usktea.plainoldv2.domain.order.OrderNumber
+import com.usktea.plainoldv2.domain.product.repository.ProductRepository
 import com.usktea.plainoldv2.domain.review.repository.ReviewRepository
+import com.usktea.plainoldv2.domain.user.repository.UserRepository
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -14,14 +18,19 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.test.context.ActiveProfiles
 
+const val USERNAME = "tjrxo1234@gamil.com"
 const val PRODUCT_ID = 1L
+const val CATEGORY_ID = 1L
+const val ORDER_NUMBER = "tjro1234-111111"
 const val ONLY_PHOTO_REVIEWS = true
 const val ALL_REVIEWS = false
 
 @ActiveProfiles("test")
 class ReviewServiceTest {
+    private val userRepository = mockk<UserRepository>()
+    private val productRepository = mockk<ProductRepository>()
     private val reviewRepository = mockk<ReviewRepository>()
-    private val reviewService = ReviewService(reviewRepository)
+    private val reviewService = ReviewService(reviewRepository, userRepository, productRepository)
 
     @Test
     fun `페이징 조건에 맞는 구매평을 조회한다`() = runTest {
@@ -39,5 +48,24 @@ class ReviewServiceTest {
         )
 
         founds shouldHaveSize 1
+    }
+
+    @Test
+    fun `사용자 요청에 맞게 구매평을 생성한다`() = runTest {
+        val username = createUsername(USERNAME)
+        val password = createPassword(PASSWORD)
+        val user = createUser(username = username, password = password)
+        val product = createProduct(productId = PRODUCT_ID, categoryId = CATEGORY_ID)
+        val postReviewRequest = createPostReviewRequest(orderNumber = ORDER_NUMBER, productId = PRODUCT_ID)
+        val review = createReview(productId = PRODUCT_ID, orderNumber = ORDER_NUMBER)
+
+        coEvery { userRepository.findByUsernameOrNull(username) } returns user
+        coEvery { productRepository.findBySpec(any()) } returns product
+        coEvery { reviewRepository.save(any()) } returns review
+
+        val saved = reviewService.postReview(username = username, postReviewRequest = postReviewRequest)
+
+        saved.productId shouldBe PRODUCT_ID
+        saved.orderNumber shouldBe OrderNumber(ORDER_NUMBER)
     }
 }


### PR DESCRIPTION
앞으로 엔티티를 저장하기 위해 연관된 엔티티를 확인하는 로직은 Repository레이어에 작성하도록 설정해야함. 
세션을 굳이 다시 열어서 확인하는 것은 자원 낭비가 있을 것으로 생각됨.